### PR TITLE
Change author's key from Symbol to String

### DIFF
--- a/lib/sqwiggle/message.rb
+++ b/lib/sqwiggle/message.rb
@@ -13,10 +13,10 @@ module Sqwiggle
     attribute :parse, Boolean, default:true
 
     def author
-      if @author[:type] == 'user'
-        client.users.find(@author[:id])
-      elsif @author[:type] == 'client'
-        client.api_clients.find(@author[:id])
+      if @author['type'] == 'user'
+        client.users.find(@author['id'])
+      elsif @author['type'] == 'client'
+        client.api_clients.find(@author['id'])
       end
     end
 


### PR DESCRIPTION
Current implementation returns `nil` when calling `author` because its key is not String.
## Sample Log

``` ruby
[5] pry(main)> msg = messages.all.first
=> #<Sqwiggle::Message:0x007ffe7daf5018
 @attachments=[],
 @author=
  {"id"=>27610,
   "name"=>"yasulab",
   "avatar"=>"https://www.gravatar.com/avatar/6dc47b9baa906db1536302a82aea3bc9?d=https%3A%2F%2Ftiley.herokuapp.com%2Favatar%2F27610%2FY.png&s=300",
   "type"=>"user",
   "support"=>false},
 @client=#<Sqwiggle::Api::Client # (70365506194540)>,
 @created_at=#<DateTime: 2015-07-03T01:58:49+00:00 ((2457207j,7129s,284000000n),+0s,2299161j)>,
 @format=nil,
 @id=4192767,
 @mentions=[],
 @parse=true,
 @room_id=nil,
 @text="hogehoge foo!",
 @type="message",
 @updated_at=#<DateTime: 2015-07-03T01:58:49+00:00 ((2457207j,7129s,284000000n),+0s,2299161j)>>
[6] pry(main)> msg.author
=> nil
```
